### PR TITLE
Update python_version for 3.13

### DIFF
--- a/geocodingmapsco.json
+++ b/geocodingmapsco.json
@@ -7,7 +7,7 @@
     "logo": "logo_geocodingmapsco.svg",
     "logo_dark": "logo_geocodingmapsco_dark.svg",
     "product_name": "Geocoding by Map Maker",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "product_version_regex": ".*",
     "publisher": "Unapproved Pty Ltd",
     "license": "Copyright (c) Unapproved, 2024-2025",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)